### PR TITLE
Decompress multiple concatenated streams

### DIFF
--- a/spec/http_decoders/gzip_spec.rb
+++ b/spec/http_decoders/gzip_spec.rb
@@ -56,6 +56,36 @@ describe HttpDecoders::GZip do
     decompressed.size.should eq(32907)
   end
 
+  it "should decompress concatenated streams" do
+    decompressed = ""
+
+    gz = HttpDecoders::GZip.new do |data|
+      decompressed << data
+    end
+
+    gz << compressed + compressed
+
+    gz.finalize!
+
+    expect(decompressed).to eq("hi\nhi\n")
+  end
+
+  it "should decompress concatenated streams byte by byte" do
+    decompressed = ""
+
+    gz = HttpDecoders::GZip.new do |data|
+      decompressed << data
+    end
+
+    (compressed * 2).each_char do |byte|
+      gz << byte
+    end
+
+    gz.finalize!
+
+    expect(decompressed).to eq("hi\nhi\n")
+  end
+
   it "should not care how many chunks the file is split up into" do
     examples = [
       ["\x1F", "\x8B", "\b", "\x00", "\x00", "\x00", "\x00", "\x00", "\x00", "\x00", "\xF3", "\xCB", "/", "Q", "p\xCB/\xCDK\x01\x00M\x8Ct\xB1\t\x00\x00\x00"],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,13 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'http_decoders'
+
+RSpec.configure do |config|
+  if ENV['CI']
+    config.before(:example, :focus) { raise "Do not commit focused specs" }
+  else
+    config.filter_run_including :focus => true
+    config.run_all_when_everything_filtered = true
+  end
+
+  config.warnings = true
+end


### PR DESCRIPTION
Multiple streams can be concatenated in one gzip file. These work in gzip, gunzip and other tools. Ruby zlib bindings do not expose the unused bytes, so Gzip magic string in the compressed chunk is used to find the start of next stream. This might need work in future.