### PR TITLE
bump bundler version to 2.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ cache: bundler
 rvm:
   - 2.3.3
   - 2.4.0
-before_install: gem install bundler -v 1.14.5
+before_install: gem install bundler -v 2.1.4

--- a/http_decoders.gemspec
+++ b/http_decoders.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
 end


### PR DESCRIPTION
There are quite many newer versions released to bundler, and for some reason travis CI fails to run `bundle install` even with the specified `before_install: gem install bundler -v 1.14.5` commands.
See: https://github.com/smartlyio/http_decoders/pull/3